### PR TITLE
docs: update outdated repository links in pull request guide

### DIFF
--- a/docs/how-to-contribute-with-pull-requests.md
+++ b/docs/how-to-contribute-with-pull-requests.md
@@ -16,17 +16,17 @@ Um pull request (PR) é como você propõe mudanças para um projeto no GitHub. 
 
 **Obrigatório antes de submeter PRs:**
 
-- **Para correções de bugs**: Crie uma issue usando o [template de bug report](https://github.com/SynkraAIinc/aiox-core/issues/new?template=bug_report.md)
+- **Para correções de bugs**: Crie uma issue usando o [template de bug report](https://github.com/SynkraAI/aiox-core/issues/new?template=bug_report.md)
 - **Para novas features**:
   1. Discuta no Discord no [canal #general-dev](https://discord.gg/gk8jAdXWmj)
-  2. Crie uma issue usando o [template de feature request](https://github.com/SynkraAIinc/aiox-core/issues/new?template=feature_request.md)
+  2. Crie uma issue usando o [template de feature request](https://github.com/SynkraAI/aiox-core/issues/new?template=feature_request.md)
 - **Para mudanças grandes**: Sempre abra uma issue primeiro para discutir o alinhamento
 
 ## Guia Passo a Passo
 
 ### 1. Fazer Fork do Repositório
 
-1. Vá para o [repositório Synkra AIOX](https://github.com/SynkraAIinc/aiox-core)
+1. Vá para o [repositório Synkra AIOX](https://github.com/SynkraAI/aiox-core)
 2. Clique no botão "Fork" no canto superior direito
 3. Isso cria sua própria cópia do projeto
 
@@ -135,8 +135,8 @@ git push origin fix/typo-in-readme
 
 ## Precisa de Ajuda?
 
-- 🐛 Reporte bugs usando o [template de bug report](https://github.com/SynkraAIinc/aiox-core/issues/new?template=bug_report.md)
-- 💡 Sugira features usando o [template de feature request](https://github.com/SynkraAIinc/aiox-core/issues/new?template=feature_request.md)
+- 🐛 Reporte bugs usando o [template de bug report](https://github.com/SynkraAI/aiox-core/issues/new?template=bug_report.md)
+- 💡 Sugira features usando o [template de feature request](https://github.com/SynkraAI/aiox-core/issues/new?template=feature_request.md)
 - 📖 Leia as [Diretrizes de Contribuição](../CONTRIBUTING.md) completas
 
 ## Exemplo: PRs Bons vs Ruins


### PR DESCRIPTION
## What

Updated five outdated repository links in the pull request contribution guide from
`SynkraAIinc/aiox-core` to `SynkraAI/aiox-core`.

## Why

The previous URLs no longer resolve and may confuse new contributors.

## How

- Updated the bug report template link
- Updated the feature request template link
- Updated the main repository link
- Updated the help-section links
- Kept the change limited to one documentation file

## Testing

Verified that all updated URLs point to the current Synkra AIOX repository.

Fixes #818

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated bug report and feature request template links to point to the correct repository.
  * Corrected links in the contribution prerequisites and help sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->