### PR TITLE
fix: branch-manager.js does not parse — await inside non-async filter callback

### DIFF
--- a/.aiox-core/development/scripts/branch-manager.js
+++ b/.aiox-core/development/scripts/branch-manager.js
@@ -211,9 +211,10 @@ class BranchManager {
     const cutoffDate = new Date();
     cutoffDate.setDate(cutoffDate.getDate() - daysOld);
 
-    const toDelete = branches.filter(branch => 
-      branch.lastCommitDate < cutoffDate && 
-      branch.name !== await this.git.getCurrentBranch()
+    const currentBranch = await this.git.getCurrentBranch();
+    const toDelete = branches.filter(branch =>
+      branch.lastCommitDate < cutoffDate &&
+      branch.name !== currentBranch
     );
 
     if (toDelete.length === 0) {


### PR DESCRIPTION
## Problem

`.aiox-core/development/scripts/branch-manager.js` does not parse. In
`cleanupOldBranches()`, `await this.git.getCurrentBranch()` sits inside the
callback passed to `branches.filter()` — and that callback is not `async`:

```js
const toDelete = branches.filter(branch =>
  branch.lastCommitDate < cutoffDate &&
  branch.name !== await this.git.getCurrentBranch()   // ← SyntaxError
);
```

This is a **syntax error, not a runtime bug** — the module never loads at all:

```console
$ node --check .aiox-core/development/scripts/branch-manager.js
branch.name !== await this.git.getCurrentBranch()
                ^^^^^
SyntaxError: missing ) after argument list
```

Any `require()` of `BranchManager` throws, so every code path through it is
currently dead. Reproduces on `main` @ `4ef6530` (v5.4.1).

## Fix

Hoist the `await` out of the callback:

```js
const currentBranch = await this.git.getCurrentBranch();
const toDelete = branches.filter(branch =>
  branch.lastCommitDate < cutoffDate &&
  branch.name !== currentBranch
);
```

The comparison is loop-invariant, so besides making the file parse this also
stops re-resolving the current branch once per element.

## Why this reached `main`

`eslint.config.js` ignores `.aiox-core/development/scripts/**`:

```js
// Development scripts with known ESLint errors (TODO: fix in future story)
'.aiox-core/development/scripts/**',
```

So neither `lint` nor `typecheck` ever parses this file, and no test requires
it. Worth considering a cheap `node --check` sweep over the ignored paths in
CI — it would have caught this without un-ignoring anything.

## Validation

| Gate | Result |
|---|---|
| `node --check` on the file | passes (failed before) |
| `npm run lint` | clean |
| `npm run typecheck` | clean |
| `npm test` | identical to baseline |

On `npm test`: 9 failures in `tests/core/orchestration/terminal-spawner.test.js`
reproduce on unmodified `main` in this environment — pre-existing and unrelated
to this change. Everything else passes (9028 passed).

## Notes

Found while updating a downstream install from 5.2.9 to 5.4.1.

One other thing surfaced that is **deliberately not in this PR**: in
`.aiox-core/core/orchestration/executors/epic-{4,5,6}-executor.js`, the lazy
`require('../../infrastructure/scripts/…')` calls resolve to
`core/infrastructure/scripts/…` — one level short of
`.aiox-core/infrastructure/scripts/`, where those five modules actually live.
Because the requires sit inside `try/catch`, they degrade silently to the
fallback path rather than failing loudly.

I did not include a fix here: correcting the paths makes the real modules load,
which changes behavior, and `tests/core/epic-executors.test.js` currently
encodes the degraded behavior (it goes 29/29 → 5 failures once the modules
resolve). That is a call for the maintainers — happy to open a separate issue
or PR if useful.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ocVsqYBvX2A9pJhGFTfDc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Branch cleanup now correctly excludes the currently active branch, preventing it from being selected for deletion during cleanup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->