### PR TITLE
test(infrastructure): pin the layer boundary against new upward imports

### DIFF
--- a/tests/infrastructure/layer-boundary.test.js
+++ b/tests/infrastructure/layer-boundary.test.js
@@ -34,17 +34,21 @@ describe('infrastructure layer boundary', () => {
 
   /**
    * Known upward imports from infrastructure/, as of AIOX 5.4.1.
-   * Key: path relative to .aiox-core/infrastructure/. Value: why it is here.
+   *
+   * Keyed by "<file> -> <target>" rather than by file alone: a file already on
+   * the list could otherwise grow a second upward import and go unnoticed.
+   * The value records what is pulled across the boundary.
    */
   const KNOWN_VIOLATIONS = {
-    'scripts/pre-dispatch-guard.js': 'core/permissions/dispatch-governance — assertDispatchGovernance',
-    'scripts/component-generator.js': 'core/elicitation/elicitation-engine — ElicitationEngine',
-    'scripts/batch-creator.js': 'core/elicitation/elicitation-engine — ElicitationEngine',
-    'scripts/framework-analyzer.js': 'development/scripts/workflow-validator — WorkflowValidator',
-    'scripts/framework-3way-diff.js': 'core/security/port-denylist — scanContent',
+    'scripts/pre-dispatch-guard.js -> core/permissions/dispatch-governance':
+      'assertDispatchGovernance',
+    'scripts/component-generator.js -> core/elicitation/elicitation-engine': 'ElicitationEngine',
+    'scripts/batch-creator.js -> core/elicitation/elicitation-engine': 'ElicitationEngine',
+    'scripts/framework-analyzer.js -> development/scripts/workflow-validator': 'WorkflowValidator',
+    'scripts/framework-3way-diff.js -> core/security/port-denylist': 'scanContent',
   };
 
-  const UPWARD_IMPORT_RE = /require\(\s*['"](?:\.\.\/)+(core|development|product)\/[^'"]*['"]\s*\)/;
+  const UPWARD_IMPORT_RE = /require\(\s*['"]((?:\.\.\/)+)(core|development|product)\/([^'"]*)['"]\s*\)/g;
 
   function collectJsFiles(dir, acc = []) {
     let entries;
@@ -66,18 +70,27 @@ describe('infrastructure layer boundary', () => {
     return acc;
   }
 
-  /** Files under infrastructure/ that import from core/, development/ or product/. */
+  /**
+   * Upward imports from infrastructure/, as "<file> -> <target>" pairs.
+   *
+   * Reporting the pair rather than the file means a new target inside an
+   * already-listed file is still a new violation.
+   */
   function findUpwardImports() {
-    const found = [];
+    const found = new Set();
 
     for (const file of collectJsFiles(INFRA_DIR)) {
       const source = fs.readFileSync(file, 'utf-8');
-      if (UPWARD_IMPORT_RE.test(source)) {
-        found.push(path.relative(INFRA_DIR, file).split(path.sep).join('/'));
+      const relFile = path.relative(INFRA_DIR, file).split(path.sep).join('/');
+
+      for (const [, , layer, rest] of source.matchAll(UPWARD_IMPORT_RE)) {
+        // Drop any trailing '/index' or extension so the target is stable.
+        const target = `${layer}/${rest}`.replace(/\.js$/, '').replace(/\/index$/, '');
+        found.add(`${relFile} -> ${target}`);
       }
     }
 
-    return found.sort();
+    return [...found].sort();
   }
 
   it('does not introduce new upward imports from infrastructure/', () => {

--- a/tests/infrastructure/layer-boundary.test.js
+++ b/tests/infrastructure/layer-boundary.test.js
@@ -1,0 +1,109 @@
+const fs = require('fs');
+const path = require('path');
+
+const REPO_ROOT = path.join(__dirname, '..', '..');
+const CORE_DIR = path.join(REPO_ROOT, '.aiox-core');
+const INFRA_DIR = path.join(CORE_DIR, 'infrastructure');
+
+/**
+ * Guards the layered dependency direction declared in
+ * `.aiox-core/infrastructure/README.md`:
+ *
+ *   infrastructure/ ← core/ ← development/ ← product/
+ *
+ *   - infrastructure/ CAN import from: nothing (base layer)
+ *   - core/          CAN import from: infrastructure/
+ *   - development/   CAN import from: infrastructure/, core/
+ *   - product/       CAN import from: infrastructure/, core/
+ *
+ * Infrastructure importing upward inverts that direction. One such import is a
+ * genuine cycle: infrastructure/{batch-creator,component-generator} →
+ * core/elicitation/elicitation-engine → infrastructure/scripts/security-checker.
+ * That cycle is already mitigated deliberately — the engine wraps its require in
+ * try/catch with a documented fallback ("resolves the cross-module dependency
+ * issue from Story 2.2") — so it does not break at load time today.
+ *
+ * These violations predate this test and are not fixed here: unwinding them means
+ * extracting ports (SecurityPolicy, WorkflowValidation, ContentScanner) and
+ * rewiring composition, which touches the nine core/ modules that import
+ * infrastructure/ legitimately. The test pins the known set so the debt stays
+ * visible and cannot grow silently. Fixing one means deleting its entry.
+ */
+describe('infrastructure layer boundary', () => {
+  const SKIP_DIRS = new Set(['node_modules', '.git', 'coverage', 'dist', 'build', '__tests__']);
+
+  /**
+   * Known upward imports from infrastructure/, as of AIOX 5.4.1.
+   * Key: path relative to .aiox-core/infrastructure/. Value: why it is here.
+   */
+  const KNOWN_VIOLATIONS = {
+    'scripts/pre-dispatch-guard.js': 'core/permissions/dispatch-governance — assertDispatchGovernance',
+    'scripts/component-generator.js': 'core/elicitation/elicitation-engine — ElicitationEngine',
+    'scripts/batch-creator.js': 'core/elicitation/elicitation-engine — ElicitationEngine',
+    'scripts/framework-analyzer.js': 'development/scripts/workflow-validator — WorkflowValidator',
+    'scripts/framework-3way-diff.js': 'core/security/port-denylist — scanContent',
+  };
+
+  const UPWARD_IMPORT_RE = /require\(\s*['"](?:\.\.\/)+(core|development|product)\/[^'"]*['"]\s*\)/;
+
+  function collectJsFiles(dir, acc = []) {
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return acc;
+    }
+
+    for (const entry of entries) {
+      if (SKIP_DIRS.has(entry.name)) continue;
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        collectJsFiles(full, acc);
+      } else if (entry.isFile() && entry.name.endsWith('.js') && !entry.name.endsWith('.test.js')) {
+        acc.push(full);
+      }
+    }
+    return acc;
+  }
+
+  /** Files under infrastructure/ that import from core/, development/ or product/. */
+  function findUpwardImports() {
+    const found = [];
+
+    for (const file of collectJsFiles(INFRA_DIR)) {
+      const source = fs.readFileSync(file, 'utf-8');
+      if (UPWARD_IMPORT_RE.test(source)) {
+        found.push(path.relative(INFRA_DIR, file).split(path.sep).join('/'));
+      }
+    }
+
+    return found.sort();
+  }
+
+  it('does not introduce new upward imports from infrastructure/', () => {
+    const actual = findUpwardImports();
+    const known = Object.keys(KNOWN_VIOLATIONS).sort();
+
+    const added = actual.filter((f) => !known.includes(f));
+
+    expect(added).toEqual([]);
+  });
+
+  it('keeps the known-violation list honest — no stale entries', () => {
+    // A fixed violation must be removed from KNOWN_VIOLATIONS, otherwise the
+    // list drifts into fiction and stops meaning anything.
+    const actual = findUpwardImports();
+    const known = Object.keys(KNOWN_VIOLATIONS).sort();
+
+    const stale = known.filter((f) => !actual.includes(f));
+
+    expect(stale).toEqual([]);
+  });
+
+  it('documents the dependency direction in the infrastructure README', () => {
+    // The rule this test enforces must stay written down where a reader looks.
+    const readme = fs.readFileSync(path.join(INFRA_DIR, 'README.md'), 'utf-8');
+
+    expect(readme).toMatch(/CAN import from: nothing \(base layer\)/);
+  });
+});


### PR DESCRIPTION
## Summary

`.aiox-core/infrastructure/README.md` declares infrastructure as the base layer:

```
infrastructure/ ← core/ ← development/ ← product/

- infrastructure/ CAN import from: nothing (base layer)
- core/          CAN import from: infrastructure/
```

Five files under `infrastructure/` import upward, inverting that direction:

| File | Imports |
|---|---|
| `scripts/pre-dispatch-guard.js` | `core/permissions/dispatch-governance` |
| `scripts/component-generator.js` | `core/elicitation/elicitation-engine` |
| `scripts/batch-creator.js` | `core/elicitation/elicitation-engine` |
| `scripts/framework-analyzer.js` | `development/scripts/workflow-validator` |
| `scripts/framework-3way-diff.js` | `core/security/port-denylist` |

Two of them form a genuine cycle: `batch-creator` / `component-generator` → `core/elicitation/elicitation-engine` → `infrastructure/scripts/security-checker`.

That cycle is **already mitigated deliberately** — `elicitation-engine` wraps the require in `try/catch` with a fallback validator and a comment citing Story 2.2 ("resolves the cross-module dependency issue"). Nothing breaks at load time today, and the full suite passes.

## What this PR does *not* do

It does not unwind the violations. Doing that means extracting ports (`SecurityPolicy`, `WorkflowValidation`, `ContentScanner`) and rewiring composition, which touches the nine `core/` modules that import `infrastructure/` legitimately — and would undo a mitigation whose original context lives in Story 2.2. That is a maintainer's call, not an outside contributor's.

## What it does

Pins the known set so the debt stays visible and cannot grow silently:

- **A sixth violation fails the build**, naming the offending file.
- **A fixed violation also fails**, until its entry is removed from the list — so the list cannot drift into fiction while the code moves on.
- Asserts the rule is still documented in the README, so the test and the prose cannot diverge.

Each entry records what it imports and why, making the remaining work explicit: fixing one means deleting its line.

## Testing

- New suite: **3 passed**.
- Verified in both directions: injecting a new upward import into `git-wrapper.js` fails the first test and names the file; removing a real violation from the source fails the second until the entry is dropped.
- Full suite: **9040 passed, 0 failed** (378 suites; 9037 before this change).
- `eslint` clean. No production code touched — this is test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added automated checks to prevent unauthorized dependencies between application layers.
  - Added validation to ensure documented dependency exceptions remain accurate.
  - Verified that infrastructure documentation describes the applicable dependency rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->